### PR TITLE
Add the ability to expose rake tasks from this gem.

### DIFF
--- a/lib/rowan_bot.rb
+++ b/lib/rowan_bot.rb
@@ -3,6 +3,7 @@ require 'rowan_bot/version'
 require 'rowan_bot/zoom_api'
 require 'rowan_bot/salesforce_api'
 require 'rowan_bot/tasks'
+require "rowan_bot/railtie" if defined?(Rails)
 
 module RowanBot
   class Error < StandardError; end

--- a/lib/rowan_bot/railtie.rb
+++ b/lib/rowan_bot/railtie.rb
@@ -1,0 +1,5 @@
+class RowanBot::Railtie < Rails::Railtie
+  rake_tasks do
+    load 'tasks/sync_docusign_to_salesforce.rake'
+  end
+end

--- a/lib/tasks/sync_docusign_to_salesforce.rake
+++ b/lib/tasks/sync_docusign_to_salesforce.rake
@@ -1,0 +1,7 @@
+namespace :sync do
+  desc 'Updates Salesforce to indicate who has signed their DocuSign waivers.'
+  task :docusign_to_salesforce do
+    puts "### the sync_docusign_to_salesforce task is running"
+    puts "### SALESFORCE_PLATFORM_USERNAME = #{ENV['SALESFORCE_PLATFORM_USERNAME']} "
+  end
+end


### PR DESCRIPTION
Created one sample task that just prints to STDOUT for now. To
add more tasks, create them in lib/tasks and load them if running
in Rails by adding them to railtie.rb.

Test Plan:
- Load this gem into a Rails app and make sure that the following runs and prints its output:
  bundle exec rake sync:docusign_to_salesforce