### PR TITLE
Fix splat issue on tasks

### DIFF
--- a/lib/rowan_bot/tasks.rb
+++ b/lib/rowan_bot/tasks.rb
@@ -16,7 +16,7 @@ module RowanBot
       logger.info('Started adding participants')
       participants.map do |participant|
         response = zoom_api.add_registrant(meeting_id, participant)
-        { **participant, 'join_url' => response['join_url'] }
+        participant.merge({ 'join_url' => response['join_url'] })
       end
     end
 


### PR DESCRIPTION
Older ruby versions do not support double splat spread for hashes with strings as keys